### PR TITLE
A root language support

### DIFF
--- a/language_generator.rb
+++ b/language_generator.rb
@@ -24,7 +24,9 @@ module Jekyll
 
       if(language)
         theurl.sub!("/#{language}/",'/')
-        theurl = "/#{language}#{theurl}"
+        if (language != 'root')
+          theurl = "/#{language}#{theurl}"
+        end
       end
       @url = theurl
     end
@@ -60,8 +62,11 @@ module Jekyll
       }).to_s
 
       language = self.data['language']
-      theurl.gsub!(".#{language}",'')
-      theurl = "/#{language}#{theurl}"
+      #puts "#{@url}: #{language}"
+      if (language != 'root')
+        theurl.gsub!(".#{language}",'')
+        theurl = "/#{language}#{theurl}"
+      end
       @url = theurl
     end
   end
@@ -147,7 +152,7 @@ module Jekyll
 
       site.pages.each { |page|
         languages = site.config['languages'].dup
-        if (page.data['multilingual'] == nil)
+        if (page.data['multilingual'] == nil && page.data['language'] != 'root')
           url = page.url
           defined_language=page.data['language']
           if(!defined_language)


### PR DESCRIPTION
A root language is a special language that causes pages to be left alone, even if there is a default language set. It is helpful in cases where there is a need for a page that has no language assigned to it and its place is static.

Example: We're hosting a blog on github pages and want index page to be some kind of a gateway where visitor has to select language (or it's selected by JavaScript after analyzing Accept header reflected by some external server).

To achieve that we should be able to create some static index in a root directory of our blog and disable shadowing of that file by any version of language-generated index. So we have two indexes: one is for /[lang] subdirectories and second is for a root directory.

Steps:
1. Create `source/index-root.html` with custom welcome message and a header:

```

---
layout: root
permalink: /index.html
language: root

---
Please select language...
```
1. Create `source/_layouts/root.html` if needed (to include `head.html` and so on), example:

```
{% capture root_url %}{{ site.root | strip_slash }}{% endcapture %}
{% include head.html %}

<body>
    <div class="container">
        <div id="content" class="inner">{{ content | expand_urls: root_url }}</div>
        </div>
</body>
</html>
```
